### PR TITLE
Fix(server): remove user connection if local addr is not avariable

### DIFF
--- a/src/server/tunnel/tcp.rs
+++ b/src/server/tunnel/tcp.rs
@@ -82,14 +82,13 @@ impl Tcp {
                         };
 
                         tokio::select! {
-                            _ = async { tokio::join!(remote_to_me_to_tunnel, tunnel_to_me_to_remote) } => {
-                                remove_bridge_sender.cancel();
-                            }
+                            _ = async { tokio::join!(remote_to_me_to_tunnel, tunnel_to_me_to_remote) } => {}
                             _ = client_cancel_receiver.cancelled() => {
                                 let _ = remote_writer.shutdown().await;
                                 let _ = tunnel_writer.shutdown().await;
                             }
                         }
+                        remove_bridge_sender.cancel();
                     });
                 }
             }


### PR DESCRIPTION
This bug occur in tcp tunnel:

server log

```
2024-07-25T08:38:55.511659Z  INFO castled::server::data_server: tcp listener on 9992 closed
2024-07-25T08:38:58.419086Z  INFO castled::server::control_server: registering tcp tunnel on remote_port remote_port=9992
2024-07-25T08:39:02.120098Z  INFO castled::server::control_server: new user connection bridge_id="c56dd25d-6b67-4b76-8bbe-03db62a3703f"
2024-07-25T08:39:02.121594Z  INFO castled::server::control_server: received start action, I am gonna start streaming bridge_id="c56dd25d-6b67-4b76-8bbe-03db62a3703f"
2024-07-25T08:39:02.121684Z  INFO castled::server::control_server: client closed streaming bridge_id="c56dd25d-6b67-4b76-8bbe-03db62a3703f"
```

client log

```
target/debug/castle tcp 9991 --remote-port 9992
2024-07-25T08:39:02.120731Z ERROR castled::client::client: failed to connect to local endpoint 127.0.0.1:9991, so let's notify the server to close the user connection
```

we don't start any program on 9991, when request 9991, the client close the connection instantly, but the server doesn't remove the user connection.


Fix:

call `remove_bridge_sender.cancel();` on any path(only call when success)

